### PR TITLE
feat(core): add Ptr helper method

### DIFF
--- a/pkg/apis/v1/role_test.go
+++ b/pkg/apis/v1/role_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	v1 "github.com/baptistegh/go-lakekeeper/pkg/apis/v1"
+	"github.com/baptistegh/go-lakekeeper/pkg/core"
 	"github.com/baptistegh/go-lakekeeper/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 )
@@ -26,15 +27,13 @@ func TestRoleService_Get(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 
-	createdAt := "2019-08-24T14:15:22Z"
-	description := "description of the role"
 	want := &v1.Role{
 		ID:          roleID,
 		ProjectID:   projectID,
 		Name:        "test-role",
-		Description: &description,
-		CreatedAt:   createdAt,
-		UpdatedAt:   &createdAt,
+		Description: core.Ptr("description of the role"),
+		CreatedAt:   "2019-08-24T14:15:22Z",
+		UpdatedAt:   core.Ptr("2019-08-24T14:15:22Z"),
 	}
 
 	assert.Equal(t, want, role)
@@ -48,20 +47,18 @@ func TestRoleService_Create(t *testing.T) {
 	projectID := "01f2fdfc-81fc-444d-8368-5b6701566e35"
 	roleID := "a4b2c1d0-e3f4-5a6b-7c8d-9e0f1a2b3c4d"
 
-	createdAt := "2019-08-24T14:15:22Z"
-	description := "description of the role"
 	want := &v1.Role{
 		ID:          roleID,
 		ProjectID:   projectID,
 		Name:        "test-role",
-		Description: &description,
-		CreatedAt:   createdAt,
-		UpdatedAt:   &createdAt,
+		Description: core.Ptr("description of the role"),
+		CreatedAt:   "2019-08-24T14:15:22Z",
+		UpdatedAt:   core.Ptr("2019-08-24T14:15:22Z"),
 	}
 
 	opts := v1.CreateRoleOptions{
 		Name:        "test-role",
-		Description: &description,
+		Description: core.Ptr("description of the role"),
 	}
 
 	mux.HandleFunc("/management/v1/role", func(w http.ResponseWriter, r *http.Request) {
@@ -89,20 +86,18 @@ func TestRoleService_Update(t *testing.T) {
 	projectID := "01f2fdfc-81fc-444d-8368-5b6701566e35"
 	roleID := "a4b2c1d0-e3f4-5a6b-7c8d-9e0f1a2b3c4d"
 
-	createdAt := "2019-08-24T14:15:22Z"
-	description := "description of the role"
 	want := &v1.Role{
 		ID:          roleID,
 		ProjectID:   projectID,
 		Name:        "test-role",
-		Description: &description,
-		CreatedAt:   createdAt,
-		UpdatedAt:   &createdAt,
+		Description: core.Ptr("description of the role"),
+		CreatedAt:   "2019-08-24T14:15:22Z",
+		UpdatedAt:   core.Ptr("2019-08-24T14:15:22Z"),
 	}
 
 	opts := v1.UpdateRoleOptions{
 		Name:        "test-role",
-		Description: &description,
+		Description: core.Ptr("description of the role"),
 	}
 
 	mux.HandleFunc("/management/v1/role/"+roleID, func(w http.ResponseWriter, r *http.Request) {
@@ -156,15 +151,13 @@ func TestRoleService_List(t *testing.T) {
 	nextPage := "8bd02c7f-1d9a-4c5c-afbb-eba7f174da09"
 	roleID := "a4b2c1d0-e3f4-5a6b-7c8d-9e0f1a2b3c4d"
 
-	createdAt := "2019-08-24T14:15:22Z"
-	description := "description of the role"
 	r := &v1.Role{
 		ID:          roleID,
 		ProjectID:   projectID,
 		Name:        "test-role",
-		Description: &description,
-		CreatedAt:   createdAt,
-		UpdatedAt:   &createdAt,
+		Description: core.Ptr("description of the role"),
+		CreatedAt:   "2019-08-24T14:15:22Z",
+		UpdatedAt:   core.Ptr("2019-08-24T14:15:22Z"),
 	}
 
 	want := v1.ListRolesResponse{

--- a/pkg/apis/v1/user_test.go
+++ b/pkg/apis/v1/user_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	v1 "github.com/baptistegh/go-lakekeeper/pkg/apis/v1"
+	"github.com/baptistegh/go-lakekeeper/pkg/core"
 	"github.com/baptistegh/go-lakekeeper/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 )
@@ -25,15 +26,13 @@ func TestUserService_Get(t *testing.T) {
 	assert.NotNil(t, resp)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	email := "test@example.com"
-	updatedAt := "2019-08-24T14:15:22Z"
 	want := &v1.User{
 		ID:              userID,
 		Name:            "test-user",
-		Email:           &email,
+		Email:           core.Ptr("test@example.com"),
 		UserType:        v1.HumanUserType,
 		CreatedAt:       "2019-08-24T14:15:22Z",
-		UpdatedAt:       &updatedAt,
+		UpdatedAt:       core.Ptr("2019-08-24T14:15:22Z"),
 		LastUpdatedWith: "create-endpoint",
 	}
 
@@ -54,15 +53,13 @@ func TestUserService_Whoami(t *testing.T) {
 	assert.NotNil(t, resp)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	email := "test@example.com"
-	updatedAt := "2019-08-24T14:15:22Z"
 	want := &v1.User{
 		ID:              "a4b2c1d0-e3f4-5a6b-7c8d-9e0f1a2b3c4d",
 		Name:            "test-user",
-		Email:           &email,
+		Email:           core.Ptr("test@example.com"),
 		UserType:        v1.HumanUserType,
 		CreatedAt:       "2019-08-24T14:15:22Z",
-		UpdatedAt:       &updatedAt,
+		UpdatedAt:       core.Ptr("2019-08-24T14:15:22Z"),
 		LastUpdatedWith: "create-endpoint",
 	}
 
@@ -74,18 +71,12 @@ func TestUserService_Provision(t *testing.T) {
 
 	mux, client := testutil.ServerMux(t)
 
-	id := "a4b2c1d0-e3f4-5a6b-7c8d-9e0f1a2b3c4d"
-	email := "test@example.com"
-	name := "test-user"
-	userType := v1.HumanUserType
-	updateIfExists := true
-
 	opts := v1.ProvisionUserOptions{
-		ID:             &id,
-		Email:          &email,
-		Name:           &name,
-		UserType:       &userType,
-		UpdateIfExists: &updateIfExists,
+		ID:             core.Ptr("a4b2c1d0-e3f4-5a6b-7c8d-9e0f1a2b3c4d"),
+		Email:          core.Ptr("test@example.com"),
+		Name:           core.Ptr("test-user"),
+		UserType:       core.Ptr(v1.HumanUserType),
+		UpdateIfExists: core.Ptr(true),
 	}
 
 	mux.HandleFunc("/management/v1/user", func(w http.ResponseWriter, r *http.Request) {
@@ -97,14 +88,13 @@ func TestUserService_Provision(t *testing.T) {
 		testutil.MustWriteHTTPResponse(t, w, "testdata/get_user.json")
 	})
 
-	updatedAt := "2019-08-24T14:15:22Z"
 	want := &v1.User{
-		ID:              id,
-		Email:           &email,
-		Name:            name,
-		UserType:        userType,
+		ID:              "a4b2c1d0-e3f4-5a6b-7c8d-9e0f1a2b3c4d",
+		Email:           core.Ptr("test@example.com"),
+		Name:            "test-user",
+		UserType:        v1.HumanUserType,
 		CreatedAt:       "2019-08-24T14:15:22Z",
-		UpdatedAt:       &updatedAt,
+		UpdatedAt:       core.Ptr("2019-08-24T14:15:22Z"),
 		LastUpdatedWith: "create-endpoint",
 	}
 

--- a/pkg/core/utils.go
+++ b/pkg/core/utils.go
@@ -1,0 +1,7 @@
+package core
+
+// Ptr is a helper function to create a pointer
+// to a value.
+func Ptr[T any](v T) *T {
+	return &v
+}

--- a/pkg/core/utils_test.go
+++ b/pkg/core/utils_test.go
@@ -1,0 +1,17 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPtr(t *testing.T) {
+	t.Parallel()
+
+	tests := []any{"string", 123, 12.3, true}
+
+	for _, test := range tests {
+		assert.Equal(t, test, *Ptr(test))
+	}
+}


### PR DESCRIPTION
## Description

Adding a new `core.Ptr()` which returns the pointer with the value in argument

**Example**

```go
ptrString := core.Ptr("I want a pointer to this string")
ptrInt := core.Ptr(128)
```