### PR TITLE
chore(ci): add v0.9.3 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,10 +79,11 @@ jobs:
     strategy:
       matrix:
         lakekeeper_version:
+          - latest-main
           # This is the only compatible version for now, due to the introduction of "skip storage validation"
           # See: https://github.com/lakekeeper/lakekeeper/pull/1239
           # The Go client should be compatible with versions >= v0.9.3 once released
-          - latest-main
+          - v0.9.3
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
It needs the published `v0.9.3` catalog image tag.