### PR TITLE
fix: typo in R2 credential

### DIFF
--- a/pkg/apis/management/v1/storage/credential/s3.go
+++ b/pkg/apis/management/v1/storage/credential/s3.go
@@ -31,7 +31,7 @@ type (
 		SecretAccessKey string `json:"secret-access-key"`
 		// Cloudflare account ID, used to determine the temporary credentials
 		// endpoint.
-		AccountID string `json:"account=id"`
+		AccountID string `json:"account-id"`
 		// Token associated with the access key ID.
 		// This is used to fetch downscoped temporary credentials
 		// for vended credentials.

--- a/pkg/apis/management/v1/storage/credential/s3_test.go
+++ b/pkg/apis/management/v1/storage/credential/s3_test.go
@@ -69,7 +69,7 @@ func TestCloudflareR2Credential(t *testing.T) {
 	b, err := json.Marshal(creds)
 	require.NoError(t, err)
 
-	jsonStr := `{"type":"s3","credential-type":"cloudflare-r2","access-key-id":"access-key","secret-access-key":"secret-key","account=id":"account-id","token":"token"}`
+	jsonStr := `{"type":"s3","credential-type":"cloudflare-r2","access-key-id":"access-key","secret-access-key":"secret-key","account-id":"account-id","token":"token"}`
 
 	assert.JSONEq(t, jsonStr, string(b))
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the JSON field name for Cloudflare R2 credential account ID to use the proper format, ensuring correct serialization of credentials.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/baptistegh/go-lakekeeper/pull/260?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->